### PR TITLE
remove-items-temp-folder

### DIFF
--- a/misc/remove-items-temp-folder.ps1
+++ b/misc/remove-items-temp-folder.ps1
@@ -1,0 +1,4 @@
+# Silently Delete all files under C:\Users\PC-NAME\AppData\Local\Temp.
+# Ignoring any errors that can be thrown.
+
+Remove-Item -Path $env:TEMP -Recurse -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
Tested that on running the powerShell script all items under %temp% folder deleted successfully.

Also tested out the scenario when some files cannot be deleted (administrative privileges), no error is thrown and script moves on to the next file in the tree.